### PR TITLE
Add implementation of proxy and deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM nginx:1.25.4-bookworm
+
+# Install htpasswd
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y apache2-utils \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Remove default configuration
+RUN rm /etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy configration file
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Generate a password file
+RUN htpasswd -bc /etc/nginx/htpasswd public heron
+
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# pypi-proxy
+
+A simple reverse proxy for the [official Python package index](https://pypi.org).
+
+## Unauthenticated
+
+`https://pypi-proxy.fly.dev` is a proxy for `https://pypi.org`.
+
+Note a `/simple` suffix is required for usage with tools like `pip`.
+
+## Authenticated
+
+`https://pypi-proxy.fly.dev/basic-auth` is a proxy for `https://pypi.org` with HTTP basic authentication.
+
+`https://files.pythonhosted.org/` is replaced with `https://pypi-proxy.fly.dev/basic-auth/files`
+in responses to avoid bypassing authentication when downloading files. Requests to `https://pypi-proxy.fly.dev/basic-auth/files` are redirected to `https://files.pythonhosted.org/`.
+
+The username is `public` and the password is `heron` and can be provided in the URL e.g. `https://public:heron@pypi-proxy.fly.dev/basic-auth`.
+
+## Contributing
+
+Build and run the image:
+
+```
+docker build -t pypi-proxy .
+docker run --rm -p 80:8080 -i pypi-proxy
+```
+
+Use `localhost` instead of the deployed domain name to test.

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,15 @@
+app = 'pypi-proxy'
+primary_region = 'ord'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,68 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+    gzip  on;
+
+    server {
+        listen 8080;
+        server_name  localhost;
+
+        location / {
+            proxy_ssl_name $host;
+            proxy_ssl_server_name on;
+            proxy_pass https://pypi.org;
+        }
+
+        location /basic-auth/ {
+            auth_basic              "authenticated";
+            auth_basic_user_file    /etc/nginx/htpasswd;
+            proxy_ssl_name $host;
+            proxy_ssl_server_name on;
+            proxy_pass https://pypi.org/;
+
+            # We need to disable encoding to perform substitution on responses
+            proxy_set_header Accept-Encoding "";
+
+            # When deployed, we want to substitute the request protocol (i.e. https)
+            # via `X-Forwarded-Proto` but this is not set during local development
+            # since there's not a proxy in front of the service.
+            if ($http_x_forwarded_proto = '') {
+                set $http_x_forwarded_proto $scheme;
+            }
+
+            sub_filter_types *;
+            sub_filter 'https://files.pythonhosted.org/' '$http_x_forwarded_proto://$host/basic-auth/files/';
+            sub_filter_once off;
+        }
+
+        location /basic-auth/files/ {
+            auth_basic              "authenticated";
+            auth_basic_user_file    /etc/nginx/htpasswd;
+            proxy_ssl_name $host;
+            proxy_ssl_server_name on;
+            proxy_pass https://files.pythonhosted.org/;
+        }
+    }
+}


### PR DESCRIPTION
See it live at https://pypi-proxy.fly.dev/

or give it a try with

```
UV_INDEX_URL=https://public:heron@pypi-proxy.fly.dev/basic-auth/simple uv pip install pylint --no-cache --reinstall -v
```