### PR TITLE
Fix missing basic authentication for `/basic-auth/` route

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,15 +1,12 @@
-
 user  nginx;
 worker_processes  auto;
 
 error_log  /var/log/nginx/error.log notice;
 pid        /var/run/nginx.pid;
 
-
 events {
     worker_connections  1024;
 }
-
 
 http {
     include       /etc/nginx/mime.types;
@@ -56,6 +53,8 @@ http {
 
         # Authenticated index proxy
         location /basic-auth/ {
+            auth_basic              "authenticated";
+            auth_basic_user_file    /etc/nginx/htpasswd;
             proxy_ssl_name $host;
             proxy_ssl_server_name on;
             proxy_pass https://pypi.org/;


### PR DESCRIPTION
Weirdly, I removed this in https://github.com/astral-sh/pypi-proxy/commit/bd1f8cf6b86a3853b3812f4c247b2d943559ff54 (#6) and just noticed